### PR TITLE
Revert "Added support for underscores in document barcodes"

### DIFF
--- a/src/iiif/tests.py
+++ b/src/iiif/tests.py
@@ -372,15 +372,6 @@ class ToolsTestCase(SimpleTestCase):
         self.assertEqual(url_info['document_barcode'], "628547")
         self.assertEqual(url_info['source_file'], True)
 
-    def test_get_info_from_wabo_url_with_underscores_in_barcode(self):
-        url_info = get_info_from_iiif_url("2/wabo:SDO-10316333-3304_ECS0000004420_000_000/info.json", False)
-        self.assertEqual(url_info['source'], "wabo")
-        self.assertEqual(url_info['stadsdeel'], "SDO")
-        self.assertEqual(url_info['dossier'], "10316333")
-        self.assertEqual(url_info['olo'], "3304")
-        self.assertEqual(url_info['document_barcode'], "ECS0000004420_000_000")
-        self.assertEqual(url_info['source_file'], False)
-
     def test_get_info_from_wabo_url_wrong_formatted_url(self):
         self.assertRaises(InvalidIIIFUrlError, get_info_from_iiif_url, "2/", False)
 

--- a/src/iiif/tools.py
+++ b/src/iiif/tools.py
@@ -60,7 +60,6 @@ def create_file_url_and_headers(request_meta, url_info, iiif_url, metadata):
 
 
 def get_image_from_iiif_server(file_url, headers, cert):
-    # curl http://iiif.service.consul:8149/iiif/2/edepot:SA-63538-SA00423873_00044.jpg
     return requests.get(file_url, headers=headers, cert=cert)
 
 
@@ -98,7 +97,7 @@ def get_info_from_iiif_url(iiif_url, source_file):
 
         elif source == 'wabo':  # = pre-wabo
             stadsdeel, dossier, olo_and_document = relevant_url_part.split('-')
-            olo, document_barcode = olo_and_document.split('_', 1)
+            olo, document_barcode = olo_and_document.split('_')
             return {
                 'source': source,
                 'stadsdeel': stadsdeel,


### PR DESCRIPTION
Reverts Amsterdam/iiif-auth-proxy#40