### PR TITLE
Feature/fix info json content type

### DIFF
--- a/src/iiif/views.py
+++ b/src/iiif/views.py
@@ -54,7 +54,7 @@ def index(request, iiif_url):
 
     return HttpResponse(
         response_content,
-        content_type=file_response.headers.get("Content-Type", content_type),
+        content_type,
     )
 
 

--- a/tests/test_iiif.py
+++ b/tests/test_iiif.py
@@ -220,6 +220,8 @@ class TestFileRetrievalWithAuthz:
 
         response = client.get(self.url + PRE_WABO_INFO_JSON_URL, **header)
         assert response.status_code == 200
+        assert response.headers['Content-Type'] == 'application/json'
+
         response_dict = json.loads(response.content)
         assert response_dict["width"] == 96
         assert response_dict["height"] == 85


### PR DESCRIPTION
Fixed a bug where the  info.json header was incorrectly set to an img.
Updated test to guarantee this does not happen again