### PR TITLE
Remove temporary exception logging

### DIFF
--- a/src/iiif/image_server.py
+++ b/src/iiif/image_server.py
@@ -120,8 +120,7 @@ def download_file_for_zip(
     try:
         file_response, file_url = get_file(request_meta, url_info, iiif_url, metadata)
         handle_file_response_codes(file_response, file_url)
-    except ImmediateHttpResponse as e:
-        log.exception(f"HTTP Exception while retrieving {iiif_url} from the source system: ({e.response.content})")
+    except ImmediateHttpResponse:
         info_txt_contents += (
             f"Not included in this zip because an error occurred "
             f"while getting it from the source system\n"


### PR DESCRIPTION
Al denk ik toch dat we de `log.info()` op `regel 82` in dit aangepaste bestand moeten veranderen in een `log.exception`. Die komt alleen voor als we een bouwdossier opvragen waarvoor we geen 404 of 200 krijgen. Dat lijkt met toch vrij buiten de norm en het lijkt me dat we dat dan willen weten. We kunnen daar nog een uitzondering aan toevoegen voor als het target systeem niet bereikbaar is zodat we dan niet overspoeld raken met exceptions in dat geval.