### PR TITLE
Bug/remove jwt token from info url

### DIFF
--- a/src/iiif/views.py
+++ b/src/iiif/views.py
@@ -35,7 +35,7 @@ def index(request, iiif_url):
 
         if url_info["info_json"]:
             response_content = generate_info_json(
-                request.build_absolute_uri().replace("/info.json", ""),
+                request.build_absolute_uri().split("/info.json")[0],
                 file_response.content,
                 file_response.headers.get("Content-Type"),
             )


### PR DESCRIPTION
Fixes double auth jwt token:
https://bouwdossiers.amsterdam.nl/iiif/2/edepot:SJ-00093-SJ10000463_00003.jpg?auth=[authcode]/full/357,/0/default.jpg?auth=[authcode]

(Replaced the actual auth code with [authcode]

- [ ] Test on Acceptation