### PR TITLE
bug/BOUW-190: Fix path to health probe page

### DIFF
--- a/src/main/urls.py
+++ b/src/main/urls.py
@@ -19,4 +19,5 @@ from django.urls import include, path
 urlpatterns = [
     path("iiif/status/health", include("health.urls")),
     path("iiif/", include("iiif.urls")),
+    path("", include("health.urls")),
 ]

--- a/src/main/urls.py
+++ b/src/main/urls.py
@@ -17,6 +17,6 @@ Including another URLconf
 from django.urls import include, path
 
 urlpatterns = [
+    path("iiif/status/health", include("health.urls")),
     path("iiif/", include("iiif.urls")),
-    path("", include("health.urls")),
 ]

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -8,12 +8,12 @@ class TestViews(SimpleTestCase):
         self.http_client = Client()
 
     def test_health_view(self):
-        response = self.http_client.get("/")
+        response = self.http_client.get("/iiif/status/health")
         assert response.status_code == 200
         assert response.content == b"Connectivity OK"
 
     @mock.patch("health.views.settings.DEBUG", True)
     def test_debug_false(self):
-        response = self.http_client.get("/")
+        response = self.http_client.get("/iiif/status/health")
         assert response.status_code == 500
         assert response.content == b"Debug mode not allowed in production"

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -8,12 +8,23 @@ class TestViews(SimpleTestCase):
         self.http_client = Client()
 
     def test_health_view(self):
-        response = self.http_client.get("/iiif/status/health")
+        response = self.http_client.get("")
         assert response.status_code == 200
         assert response.content == b"Connectivity OK"
 
     @mock.patch("health.views.settings.DEBUG", True)
     def test_debug_false(self):
+        response = self.http_client.get("")
+        assert response.status_code == 500
+        assert response.content == b"Debug mode not allowed in production"
+
+    def test_health_view_extra_path(self):
+        response = self.http_client.get("/iiif/status/health")
+        assert response.status_code == 200
+        assert response.content == b"Connectivity OK"
+
+    @mock.patch("health.views.settings.DEBUG", True)
+    def test_debug_false_extra_path(self):
         response = self.http_client.get("/iiif/status/health")
         assert response.status_code == 500
         assert response.content == b"Debug mode not allowed in production"


### PR DESCRIPTION
Changes path to health status page from root to path requested by (unknown?) application