### PR TITLE
Default image for files other than an image (currenlty only other files supported are PDF files)

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -7,8 +7,9 @@ x-app: &base-app
     - azurite
   volumes:
     - .:/app/
-  ports:
-    - "8000:8000"
+  networks:
+    - amsterdam-bouwdossiers
+    - default
   environment: &base-app-env
     LOG_LEVEL: "WARNING"
     DJANGO_LOG_LEVEL: "WARNING"
@@ -37,6 +38,8 @@ services:
     build:
       context: .
       target: app
+    ports:
+      - "8000:8000"
     image: ${REGISTRY:-localhost:5000}/${REPOSITORY:-opdrachten/iiif-auth-proxy}:${VERSION:-latest}
     command: /app/deploy/docker-run.sh
 
@@ -45,6 +48,8 @@ services:
     build:
       context: .
       target: dev
+    ports:
+      - "8001:8000"
     environment:
       <<: *base-app-env
       LOG_LEVEL: "DEBUG"
@@ -71,3 +76,8 @@ services:
       target: linting
     volumes:
       - .:/app/
+
+networks:
+  amsterdam-bouwdossiers:
+    name: amsterdam-bouwdossiers
+    driver: bridge

--- a/src/iiif/image_handling.py
+++ b/src/iiif/image_handling.py
@@ -100,6 +100,17 @@ def is_image_content_type(content_type):
     return content_type.split("/")[0] == "image"
 
 
+def can_generate_default_thumbnail_for(content_type: str) -> bool:
+    """
+    Currently only PDF files are supported.
+    """
+    return content_type.lower() in [
+        "application/pdf",
+        "application/x-pdf",
+        "applications/pdf",
+    ]
+
+
 def content_type_to_format(content_type):
     return content_type.split("/")[1]
 

--- a/src/iiif/image_handling.py
+++ b/src/iiif/image_handling.py
@@ -100,17 +100,6 @@ def is_image_content_type(content_type):
     return content_type.split("/")[0] == "image"
 
 
-def can_generate_default_thumbnail_for(content_type: str) -> bool:
-    """
-    Currently only PDF files are supported.
-    """
-    return content_type.lower() in [
-        "application/pdf",
-        "application/x-pdf",
-        "applications/pdf",
-    ]
-
-
 def content_type_to_format(content_type):
     return content_type.split("/")[1]
 

--- a/src/iiif/image_server.py
+++ b/src/iiif/image_server.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from functools import partial
 from io import BytesIO
 
 import requests
@@ -57,11 +58,26 @@ def create_file_url_and_headers(url_info, metadata):
     raise FileSourceNotValidError(f'File source: {url_info["source"]} invalid')
 
 
-def create_mock_image(image_format):
-    img = Image.new("RGB", (32, 32), color="green")
+def _create_image(
+    file_format: str | None = None,
+    size: tuple[int, int] | None = None,
+    color: str | int | float = 0,
+) -> bytes:
+    # Use the given values or the default values
+    size = size or (32, 32)
+
+    # Create the mock image
+    img = Image.new("RGB", size=size, color=color)
     buf = BytesIO()
-    img.save(buf, format=image_format)
+    img.save(buf, format=file_format)
     return buf.getvalue()
+
+
+# Used for testing and development
+create_mock_image = partial(_create_image, size=(32, 32), color="green")
+
+# Used to create a "default thumbnail" for files that are requested and are not an image itself
+create_non_image_file_thumbnail = partial(_create_image, size=(180, 180), color="green")
 
 
 # For develop/test environments where we don't have access to the upstream server

--- a/src/iiif/views.py
+++ b/src/iiif/views.py
@@ -9,11 +9,13 @@ from toolz import partial, pipe
 from auth_mail import authentication
 from iiif import image_server, parsing
 from iiif.image_handling import (
+    can_generate_default_thumbnail_for,
     crop_image,
     generate_info_json,
     is_image_content_type,
     scale_image,
 )
+from iiif.image_server import create_non_image_file_thumbnail
 from iiif.metadata import get_metadata
 from main import utils
 
@@ -57,7 +59,12 @@ def index(request, iiif_url):
                 is_cacheable, HttpResponse(file_content, file_type)
             )
 
-        if not is_image_content_type(file_type):
+        if can_generate_default_thumbnail_for(content_type=file_type):
+            # The requested file is NOT an image itself, but we can create a thumbnail for it so let's create it.
+            file_content = create_non_image_file_thumbnail(file_format="jpeg")
+            file_type = "image/jpeg"
+        elif not is_image_content_type(file_type):
+            # Not an image return a 400
             raise utils.ImmediateHttpResponse(
                 response=HttpResponse(
                     "Content-type of requested file not supported", status=400

--- a/src/iiif/views.py
+++ b/src/iiif/views.py
@@ -9,7 +9,6 @@ from toolz import partial, pipe
 from auth_mail import authentication
 from iiif import image_server, parsing
 from iiif.image_handling import (
-    can_generate_default_thumbnail_for,
     crop_image,
     generate_info_json,
     is_image_content_type,
@@ -59,17 +58,10 @@ def index(request, iiif_url):
                 is_cacheable, HttpResponse(file_content, file_type)
             )
 
-        if can_generate_default_thumbnail_for(content_type=file_type):
+        if not is_image_content_type(file_type):
             # The requested file is NOT an image itself, but we can create a thumbnail for it so let's create it.
             file_content = create_non_image_file_thumbnail(file_format="jpeg")
             file_type = "image/jpeg"
-        elif not is_image_content_type(file_type):
-            # Not an image return a 400
-            raise utils.ImmediateHttpResponse(
-                response=HttpResponse(
-                    "Content-type of requested file not supported", status=400
-                )
-            )
 
         if url_info["info_json"]:
             response_content = generate_info_json(

--- a/tests/test_iiif.py
+++ b/tests/test_iiif.py
@@ -150,27 +150,6 @@ class TestFileRetrievalWithAuthz:
 
     @patch("iiif.image_server.get_image_from_server")
     @patch("iiif.metadata.do_metadata_request")
-    def test_get_info_json_non_image_raises(
-        self, mock_do_metadata_request, mock_get_image_from_server, client
-    ):
-        mock_do_metadata_request.return_value = MockResponse(
-            200,
-            json_content=PRE_WABO_METADATA_CONTENT,
-        )
-        mock_get_image_from_server.return_value = MockResponse(
-            200, content=b"b", headers={"Content-Type": "text/xml"}
-        )
-
-        header = {
-            "HTTP_AUTHORIZATION": "Bearer "
-            + create_authz_token(settings.BOUWDOSSIER_READ_SCOPE)
-        }
-
-        response = client.get(self.url + PRE_WABO_INFO_JSON_URL, **header)
-        assert response.status_code == 400
-
-    @patch("iiif.image_server.get_image_from_server")
-    @patch("iiif.metadata.do_metadata_request")
     def test_get_info_json(
         self, mock_do_metadata_request, mock_get_image_from_server, client
     ):
@@ -583,27 +562,6 @@ class TestFileRetrievalWithAuthz:
         response = client.get(
             self.url + PRE_WABO_IMG_URL_WITH_REGION_NON_OVERLAPPING, **header
         )
-        assert response.status_code == 400
-
-    @patch("iiif.image_server.get_image_from_server")
-    @patch("iiif.metadata.do_metadata_request")
-    def test_get_edited_file_on_non_image_returns_400(
-        self, mock_do_metadata_request, mock_get_image_from_server, client
-    ):
-        mock_do_metadata_request.return_value = MockResponse(
-            200,
-            json_content=PRE_WABO_METADATA_CONTENT,
-        )
-        mock_get_image_from_server.return_value = MockResponse(
-            200, content=b"", headers={"Content-Type": "text/xml"}
-        )
-
-        header = {
-            "HTTP_AUTHORIZATION": "Bearer "
-            + create_authz_token(settings.BOUWDOSSIER_READ_SCOPE)
-        }
-
-        response = client.get(self.url + PRE_WABO_IMG_URL_WITH_SCALING, **header)
         assert response.status_code == 400
 
 


### PR DESCRIPTION
When a thumbnail has been requested for a NON image file, a "green" thumbnail of 180X180 is generated. Currently the only other file type supported is PDF.

